### PR TITLE
FO: Select product by Enter-key

### DIFF
--- a/views/js/ps_searchbarjqauto.js
+++ b/views/js/ps_searchbarjqauto.js
@@ -23,6 +23,7 @@ $(document).ready(function () {
                 '</div>';
         },
         onSelect: function (e, term, item) {
+            e.preventDefault();
             window.location.href = item.data('url');
         }
     });


### PR DESCRIPTION
Disabling the default behaviour of the enter-key. Now the redirection to the url works. Without disabling, the default search is performed with an empty query string.