### PR TITLE
Fix error when there is no cover images in product

### DIFF
--- a/ps_searchbarjqauto.php
+++ b/ps_searchbarjqauto.php
@@ -28,6 +28,7 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
+use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
 
 class Ps_Searchbarjqauto extends Module implements WidgetInterface
@@ -62,6 +63,8 @@ class Ps_Searchbarjqauto extends Module implements WidgetInterface
 
     public function hookHeader()
     {
+        $imageRetriever = new ImageRetriever($this->context->link);
+        Media::addJsDef(array('no_picture_image' => $imageRetriever->getNoPictureImage($this->context->language)));
         $this->context->controller->registerStylesheet('modules-ps_searchbarjqauto', 'modules/'.$this->name.'/views/css/jquery.auto-complete.css', ['media' => 'all', 'priority' => 150]);
         $this->context->controller->registerJavascript('modules-autocomplete', 'modules/'.$this->name.'/views/js/jquery.auto-complete.min.js', ['position' => 'bottom', 'priority' => 150]);
         $this->context->controller->registerJavascript('modules-ps_searchbarjqauto', 'modules/'.$this->name.'/views/js/ps_searchbarjqauto.js', ['position' => 'bottom', 'priority' => 150]);

--- a/views/js/ps_searchbarjqauto.js
+++ b/views/js/ps_searchbarjqauto.js
@@ -17,10 +17,17 @@ $(document).ready(function () {
         },
         renderItem: function (product, search) {
 
-            return '<div class="media autocomplete-suggestion" data-url="' + product.url + '">' +
-                '<img class="mr-1" src="' + product.cover.bySize.small_default.url + '" width="' + product.cover.bySize.small_default.width + '" height="' + product.cover.bySize.small_default.height + '">' +
-                '<div class="media-body">' + product.name + '</div>' +
-                '</div>';
+            if(product.cover) {
+                return '<div class="media autocomplete-suggestion" data-url="' + product.url + '">' +
+                  '<img class="mr-1" src="' + product.cover.bySize.small_default.url + '" width="' + product.cover.bySize.small_default.width + '" height="' + product.cover.bySize.small_default.height + '">' +
+                  '<div class="media-body">' + product.name + '</div>' +
+                  '</div>';
+            } else {
+                return '<div class="media autocomplete-suggestion" data-url="' + product.url + '">' +
+                  '<img class="mr-1" src="' + no_picture_image.bySize.small_default.url + '" width="' + no_picture_image.bySize.small_default.width + '" height="' + no_picture_image.bySize.small_default.height + '">' +
+                  '<div class="media-body">' + product.name + '</div>' +
+                  '</div>';
+            }
         },
         onSelect: function (e, term, item) {
             e.preventDefault();


### PR DESCRIPTION
Previously we did get error in renderItem method in ps_searchbarjqauto.js file  because product.cover was null.

This new code sets variables $no_picture_image from ImageRetriever and returns it when product.cover is null.